### PR TITLE
Now checks whether title attribute exists and that it is not empty

### DIFF
--- a/jquery.jshowoff.js
+++ b/jquery.jshowoff.js
@@ -228,7 +228,7 @@ speed :				time each slide is shown [integer, milliseconds, defaults to 3000]
 			function addSlideLinks() {
 				$wrap.append('<p class="jshowoff-slidelinks '+uniqueClass+'-slidelinks"></p>');
 				$.each(gallery, function(i, val) {
-					var linktext = $(this).attr('title') != '' ? $(this).attr('title') : i+1;
+					var linktext = $(this).attr('title') || i+1;
 					$('<a class="jshowoff-slidelink-'+i+' '+uniqueClass+'-slidelink-'+i+'" href="#null">'+linktext+'</a>').bind('click', {index:i}, function(e){ goToAndPause(e.data.index); return false; }).appendTo('.'+uniqueClass+'-slidelinks');
 				});
 			};		


### PR DESCRIPTION
I came across a problem when not setting the slide element's title attribute. The controls would render as "undefined".

This fix checks whether the title attribute exists and that it is not an empty string.
